### PR TITLE
Preserve node arguments with spaces

### DIFF
--- a/bin/helpers/node
+++ b/bin/helpers/node
@@ -1,1 +1,4 @@
-${MAGIC_WS_REAL_NODE} -r ${MAGIC_WS_BOOTSTRAP_PATH} $@
+#!/bin/bash
+# $@ must be quoted to preserve whitespace in arguments.
+# cf final line of magic-ws
+${MAGIC_WS_REAL_NODE} -r ${MAGIC_WS_BOOTSTRAP_PATH} "$@"

--- a/bin/magic-ws
+++ b/bin/magic-ws
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Our goal is to determine where this script is so we can then locate our custom
 # node. Unfortunately, doing this reliably and POSIX-compliantly seems to be a
@@ -89,4 +89,8 @@ done
 
 export MAGIC_WS_BOOTSTRAP_ARGS
 
-$@
+# $@ contains the remaining arguments (ie, the argv to execute node).
+# Wrapping in quotes prevents $@ from being reinterpreted, which would (among
+# other things) cause bash to re-split the argument list at spaces, breaking
+# arguments containing spaces into multiple arguments.
+"$@"


### PR DESCRIPTION
Previously, arguments with spaces in them would get re-split before being passed to node.  So, for instance, the following command:

    magic-ws -p "/path/to/project/*" node /path/to/bin.js --arg "with a space"

would result in running bin.js with the following contents in argv:

    ['/path/to/node', '/path/to/bin.js', '--arg', 'with', 'a', 'space']

With this change, bin.js will receive the correct argv:

    ['/path/to/node', '/path/to/bin.js', '--arg', 'with a space']

Note that this change requires the script to use /bin/bash instead of /bin/sh.